### PR TITLE
Support linux kernel >=4.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - linux
 sudo: required
 before_install:
-  - go get github.com/golang/lint/golint
+  - go get golang.org/x/lint/golint
   - go get honnef.co/go/tools/cmd/staticcheck
   - go get -d ./...
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: go
 go:
   - 1.x
+env:
+  - GO111MODULE=on
 os:
   - linux
 sudo: required

--- a/get.go
+++ b/get.go
@@ -160,7 +160,7 @@ func getQdiscMsgs(c *netlink.Conn) ([]netlink.Message, error) {
 			Flags: netlink.HeaderFlagsRequest | netlink.HeaderFlagsDump,
 			Type:  38, // RTM_GETQDISC
 		},
-		Data: []byte{0},
+		Data: make([]byte, 20),
 	}
 
 	// Perform a request, receive replies, and validate the replies

--- a/get.go
+++ b/get.go
@@ -192,7 +192,7 @@ func parseMessage(msg netlink.Message) (QdiscInfo, error) {
 	*/
 
 	if len(msg.Data) < 20 {
-		return m, fmt.Errorf("Short message, len=%d", len(msg.Data))
+		return m, fmt.Errorf("short message, len=%d", len(msg.Data))
 	}
 
 	ifaceIdx := nlenc.Uint32(msg.Data[4:8])

--- a/get_test.go
+++ b/get_test.go
@@ -36,7 +36,7 @@ func TestGetAndParseShort(t *testing.T) {
 		t.Fatalf("msgs should be nil, got '%v' instead", msgs)
 	}
 
-	if err.Error() != "Short message, len=4" {
+	if err.Error() != "short message, len=4" {
 		t.Fatalf("expected short message error, got '%v' instead", err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/ema/qdisc
+
+go 1.12
+
+require (
+	github.com/mdlayher/netlink v0.0.0-20180516140058-ef6039541fbb
+)


### PR DESCRIPTION
Linux kernel 4.12 introduced a check on the size of tcmsg that should accompany RTM_GETQDISC (+dump)
https://github.com/torvalds/linux/commit/49b499718fa1b0d639663cfd03085b9bfd23cdc8#diff-da159ca526085779af0bceba0e0345acR1518

This change includes a null tcmsg of suitable size.
https://github.com/torvalds/linux/blob/49b499718fa1b0d639663cfd03085b9bfd23cdc8/include/uapi/linux/rtnetlink.h#L527

This change was tested (simply) against various versions:
3.13.0, 4.4.0, 4.5.0, 4.10.0, 4.11.12 - Old code works. This change works.
4.12.0, 4.13.0, 4.15.0, 5.0.10 - Old code fails. This change works.