### PR TITLE
Add queue length/backlog stats

### DIFF
--- a/get.go
+++ b/get.go
@@ -86,6 +86,8 @@ type QdiscInfo struct {
 	GcFlows     uint64
 	Throttled   uint64
 	FlowsPlimit uint64
+	Qlen        uint32
+	Backlog     uint32
 }
 
 func parseTCAStats(attr netlink.Attribute) TC_Stats {
@@ -237,6 +239,8 @@ func parseMessage(msg netlink.Message) (QdiscInfo, error) {
 			// requeues only available in TCA_STATS2, not in TCA_STATS
 			m.Requeues = s2.Requeues
 			m.Overlimits = s2.Overlimits
+			m.Qlen = s2.Qlen
+			m.Backlog = s2.Backlog
 		case TCA_STATS:
 			// Legacy
 			s = parseTCAStats(attr)
@@ -244,6 +248,8 @@ func parseMessage(msg netlink.Message) (QdiscInfo, error) {
 			m.Packets = s.Packets
 			m.Drops = s.Drops
 			m.Overlimits = s.Overlimits
+			m.Qlen = s.Qlen
+			m.Backlog = s.Backlog
 		default:
 			// TODO: TCA_OPTIONS and TCA_XSTATS
 		}


### PR DESCRIPTION
qdisc queue length (in packets) and backlog (in bytes) statistics, which are helpful in measuring congestion, are exposed via netlink tc stats. These are parsed out from the netlink message but don't seem to be exposed in the public `QdiscInfo` struct. This PR adds queue length and backlog to said struct.